### PR TITLE
Add validation to child attribute of FieldSchema

### DIFF
--- a/lib/functional-constraints/deepNestedFields.js
+++ b/lib/functional-constraints/deepNestedFields.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const _ = require('lodash');
+const jsonschema = require('jsonschema');
+
+const collectErrors = (inputFields, path) => {
+  const errors = [];
+
+  _.each(inputFields, (inputField, index) => {
+    if (inputField.children) {
+      const hasDeeplyNestedChildren = _.every(inputField.chilren, (child) => child.children);
+      console.log(hasDeeplyNestedChildren);
+
+      if (hasDeeplyNestedChildren) {
+        errors.push(new jsonschema.ValidationError(
+          'must not contain deeply nested child fields. One level max.',
+          inputField,
+          '/FieldSchema',
+          `instance.${path}.inputFields[${index}]`,
+          'deepNesting',
+          'inputFields'
+        ));
+      }
+    }
+  });
+
+  return errors;
+};
+
+const validateFieldNesting = (definition) => {
+  let errors = [];
+
+  _.each(['triggers', 'searches', 'creates'], (typeOf) => {
+    if (definition[typeOf]) {
+      _.each(definition[typeOf], (actionDef) => {
+        if (actionDef.operation && actionDef.operation.inputFields) {
+          errors = errors.concat(collectErrors(actionDef.operation.inputFields, `${typeOf}.${actionDef.key}`));
+        }
+      });
+    }
+  });
+
+  return errors;
+};
+
+module.exports = validateFieldNesting;

--- a/lib/functional-constraints/deepNestedFields.js
+++ b/lib/functional-constraints/deepNestedFields.js
@@ -9,7 +9,6 @@ const collectErrors = (inputFields, path) => {
   _.each(inputFields, (inputField, index) => {
     if (inputField.children) {
       const hasDeeplyNestedChildren = _.every(inputField.chilren, (child) => child.children);
-      console.log(hasDeeplyNestedChildren);
 
       if (hasDeeplyNestedChildren) {
         errors.push(new jsonschema.ValidationError(

--- a/lib/functional-constraints/index.js
+++ b/lib/functional-constraints/index.js
@@ -11,7 +11,8 @@
  *   );
 */
 const checks = [
-  require('./searchOrCreateKeys')
+  require('./searchOrCreateKeys'),
+  require('./deepNestedFields')
 ];
 
 const runFunctionalConstraints = (definition) => {

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -2,6 +2,8 @@
 
 const makeSchema = require('../utils/makeSchema');
 
+const FieldsSchema = require('./FieldsSchema');
+
 const RefResourceSchema = require('./RefResourceSchema');
 
 module.exports = makeSchema({
@@ -85,8 +87,7 @@ module.exports = makeSchema({
     },
     children: {
       description: 'Can a user provide multiples of this field? A.K.A. Line Items.',
-      // TODO: don't allow deep nesting?
-      // $ref: FieldsSchema.id,
+      $ref: FieldsSchema.id,
     },
     dict: {
       description: 'Is this field a key/value input?',

--- a/test/functional-constraints/deepNestedFields.js
+++ b/test/functional-constraints/deepNestedFields.js
@@ -1,0 +1,44 @@
+'use strict';
+
+require('should');
+const schema = require('../../schema');
+
+describe('deepNestedFields', () => {
+  it('should error on fields nested more than one level deep', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {key: 'orderId', type: 'number'},
+              {
+                key: 'line_items',
+                children: [
+                  {
+                    key: 'product',
+                    children: [
+                      {key: 'name', type: 'string'}
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[1] must not contain deeply nested child fields. One level max.');
+  });
+});


### PR DESCRIPTION
While building an app I found that I could put anything I wanted in the `children` prop of a field. Coincidentally this caused a 500 in Zapier. While that should be fixed, we ought to guide people to the right structure to begin with.