### PR TITLE
Adding authentication.connectionLabel, test coverage, and some more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.zip
 *.log
+coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
-image: node:4.3.2
+image: node:6.10.2
 
 all_tests:
   script:
    - npm install
-   - npm test
+   - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "6.10.2"
+script:
+  - npm run coverage
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `npm test` for running tests
 - `npm run export` for updating the exported-schema (even if only the version changes)
 - `npm run docs` for updating docs (even if only the version changes)
+- `npm coverage` for running tests and displaying test coverage
 
 ## Publishing (after merging)
 

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -156,7 +156,29 @@ Represents authentication schemes.
 * **Pattern** - _n/a_
 * **Source Code** - [lib/schemas/AuthenticationSchema.js](https://github.com/zapier/zapier-platform-schema/blob/v2.0.0/lib/schemas/AuthenticationSchema.js)
 
+#### Examples
 
+* `{ type: 'basic', test: '$func$2$f$' }`
+* `{ type: 'custom',
+  test: '$func$2$f$',
+  fields: [ { key: 'abc' } ] }`
+* `{ type: 'custom', test: '$func$2$f$', connectionLabel: 'abc' }`
+* `{ type: 'custom',
+  test: '$func$2$f$',
+  connectionLabel: '$func$2$f$' }`
+* `{ type: 'custom',
+  test: '$func$2$f$',
+  connectionLabel: { url: 'abc' } }`
+
+#### Anti-Examples
+
+* `{}`
+* `'$func$2$f$'`
+* `{ type: 'unknown', test: '$func$2$f$' }`
+* `{ type: 'custom', test: '$func$2$f$', fields: '$func$2$f$' }`
+* `{ type: 'custom',
+  test: '$func$2$f$',
+  fields: [ { key: 'abc' }, '$func$2$f$' ] }`
 
 #### Properties
 
@@ -165,6 +187,7 @@ Key | Required | Type | Description
 `type` | **yes** | `string` in (`'basic'`, `'custom'`, `'digest'`, `'oauth2'`, `'session'`) | Choose which scheme you want to use.
 `test` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | A function or request that confirms the authentication is working.
 `fields` | no | [/FieldsSchema](#fieldsschema) | Fields you can request from the user before they connect your app to Zapier.
+`connectionLabel` | no | anyOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema), `string`) | A string with variables, function, or request that returns the connection label for the authenticated user.
 `basicConfig` | no | [/AuthenticationBasicConfigSchema](#authenticationbasicconfigschema) | _No description given._
 `customConfig` | no | [/AuthenticationCustomConfigSchema](#authenticationcustomconfigschema) | _No description given._
 `digestConfig` | no | [/AuthenticationDigestConfigSchema](#authenticationdigestconfigschema) | _No description given._

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -164,7 +164,7 @@ Represents authentication schemes.
   fields: [ { key: 'abc' } ] }`
 * `{ type: 'custom',
   test: '$func$2$f$',
-  connectionLabel: '{{inputData.abc}}' }`
+  connectionLabel: '{{bundle.inputData.abc}}' }`
 * `{ type: 'custom',
   test: '$func$2$f$',
   connectionLabel: '$func$2$f$' }`

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -162,7 +162,9 @@ Represents authentication schemes.
 * `{ type: 'custom',
   test: '$func$2$f$',
   fields: [ { key: 'abc' } ] }`
-* `{ type: 'custom', test: '$func$2$f$', connectionLabel: 'abc' }`
+* `{ type: 'custom',
+  test: '$func$2$f$',
+  connectionLabel: '{{inputData.abc}}' }`
 * `{ type: 'custom',
   test: '$func$2$f$',
   connectionLabel: '$func$2$f$' }`

--- a/examples/definition.json
+++ b/examples/definition.json
@@ -34,7 +34,8 @@
       },
       "scope": "tags,users,contacts",
       "autoRefresh": false
-    }
+    },
+    "connectionLabel": "{{inputData.email}}"
   },
   "resources": {
     "tag": {

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -987,6 +987,20 @@
           "description": "Fields you can request from the user before they connect your app to Zapier.",
           "$ref": "/FieldsSchema"
         },
+        "connectionLabel": {
+          "description": "A string with variables, function, or request that returns the connection label for the authenticated user.",
+          "anyOf": [
+            {
+              "$ref": "/RequestSchema"
+            },
+            {
+              "$ref": "/FunctionSchema"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
         "basicConfig": {
           "$ref": "/AuthenticationBasicConfigSchema"
         },

--- a/lib/schemas/AuthenticationSchema.js
+++ b/lib/schemas/AuthenticationSchema.js
@@ -14,6 +14,20 @@ const RequestSchema = require('./RequestSchema');
 module.exports = makeSchema({
   id: '/AuthenticationSchema',
   description: 'Represents authentication schemes.',
+  examples: [
+    {type: 'basic', test: '$func$2$f$'},
+    {type: 'custom', test: '$func$2$f$', fields: [{key: 'abc'}]},
+    {type: 'custom', test: '$func$2$f$', connectionLabel: 'abc'},
+    {type: 'custom', test: '$func$2$f$', connectionLabel: '$func$2$f$'},
+    {type: 'custom', test: '$func$2$f$', connectionLabel: {url: 'abc'}},
+  ],
+  antiExamples: [
+    {},
+    '$func$2$f$',
+    {type: 'unknown', test: '$func$2$f$'},
+    {type: 'custom', test: '$func$2$f$', fields: '$func$2$f$'},
+    {type: 'custom', test: '$func$2$f$', fields: [{key: 'abc'}, '$func$2$f$']},
+  ],
   type: 'object',
   required: ['type', 'test'],
   properties: {
@@ -25,28 +39,36 @@ module.exports = makeSchema({
         'custom',
         'digest',
         'oauth2',
-        'session'
-      ]
+        'session',
+      ],
     },
     test: {
       description: 'A function or request that confirms the authentication is working.',
       oneOf: [
         {$ref: RequestSchema.id},
-        {$ref: FunctionSchema.id}
+        {$ref: FunctionSchema.id},
       ]
     },
     fields: {
       description: 'Fields you can request from the user before they connect your app to Zapier.',
-      $ref: FieldsSchema.id // TODO: can this be DynamicFieldsSchema?
+      $ref: FieldsSchema.id,
+    },
+    connectionLabel: {
+      description: 'A string with variables, function, or request that returns the connection label for the authenticated user.',
+      anyOf: [
+        {$ref: RequestSchema.id},
+        {$ref: FunctionSchema.id},
+        {type: 'string'},
+      ],
     },
     // this is preferred to laying out config: anyOf: [...]
     basicConfig: {$ref: AuthenticationBasicConfigSchema.id},
     customConfig: {$ref: AuthenticationCustomConfigSchema.id},
     digestConfig: {$ref: AuthenticationDigestConfigSchema.id},
     oauth2Config: {$ref: AuthenticationOAuth2ConfigSchema.id},
-    sessionConfig: {$ref: AuthenticationSessionConfigSchema.id}
+    sessionConfig: {$ref: AuthenticationSessionConfigSchema.id},
   },
-  additionalProperties: false
+  additionalProperties: false,
 }, [
   FieldsSchema,
   FunctionSchema,
@@ -55,5 +77,5 @@ module.exports = makeSchema({
   AuthenticationCustomConfigSchema,
   AuthenticationDigestConfigSchema,
   AuthenticationOAuth2ConfigSchema,
-  AuthenticationSessionConfigSchema
+  AuthenticationSessionConfigSchema,
 ]);

--- a/lib/schemas/AuthenticationSchema.js
+++ b/lib/schemas/AuthenticationSchema.js
@@ -17,7 +17,7 @@ module.exports = makeSchema({
   examples: [
     {type: 'basic', test: '$func$2$f$'},
     {type: 'custom', test: '$func$2$f$', fields: [{key: 'abc'}]},
-    {type: 'custom', test: '$func$2$f$', connectionLabel: 'abc'},
+    {type: 'custom', test: '$func$2$f$', connectionLabel: '{{inputData.abc}}'},
     {type: 'custom', test: '$func$2$f$', connectionLabel: '$func$2$f$'},
     {type: 'custom', test: '$func$2$f$', connectionLabel: {url: 'abc'}},
   ],

--- a/lib/schemas/AuthenticationSchema.js
+++ b/lib/schemas/AuthenticationSchema.js
@@ -17,7 +17,7 @@ module.exports = makeSchema({
   examples: [
     {type: 'basic', test: '$func$2$f$'},
     {type: 'custom', test: '$func$2$f$', fields: [{key: 'abc'}]},
-    {type: 'custom', test: '$func$2$f$', connectionLabel: '{{inputData.abc}}'},
+    {type: 'custom', test: '$func$2$f$', connectionLabel: '{{bundle.inputData.abc}}'},
     {type: 'custom', test: '$func$2$f$', connectionLabel: '$func$2$f$'},
     {type: 'custom', test: '$func$2$f$', connectionLabel: {url: 'abc'}},
   ],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "version": "npm run export && git add exported-schema.json && npm run docs && git add README.md docs/*",
     "postversion": "git push && git push --tags && npm publish",
     "test": "node_modules/mocha/bin/mocha --recursive",
+    "coverage": "node node_modules/.bin/istanbul cover _mocha -- --recursive",
     "export": "node bin/export.js",
     "docs": "node bin/docs.js"
   },
@@ -23,6 +24,7 @@
     "babel": "6.5.2",
     "babel-eslint": "6.1.2",
     "eslint": "3.4.0",
+    "istanbul": "0.4.5",
     "marked-toc": "0.3.0",
     "mocha": "3.0.2",
     "should": "11.1.0"


### PR DESCRIPTION
This requires https://github.com/zapier/zapier/pull/12448 to be shipped before merging.

This allows using the soon-to-be-shipped feature of setting connection labels.