### PR TITLE
Adding `shouldLock` to BasicActionOperationSchema.

### DIFF
--- a/lib/schemas/BasicActionOperationSchema.js
+++ b/lib/schemas/BasicActionOperationSchema.js
@@ -23,10 +23,6 @@ BasicActionOperationSchema.properties = {
       {$ref: FunctionSchema.id}
     ]
   },
-  shouldLock: {
-    description: 'Should this action be performed one at a time (avoid concurrency)? Only available for create.',
-    type: 'boolean',
-  },
   inputFields: BasicActionOperationSchema.properties.inputFields,
   outputFields: BasicActionOperationSchema.properties.outputFields,
   sample: BasicActionOperationSchema.properties.sample,

--- a/lib/schemas/BasicActionOperationSchema.js
+++ b/lib/schemas/BasicActionOperationSchema.js
@@ -23,6 +23,10 @@ BasicActionOperationSchema.properties = {
       {$ref: FunctionSchema.id}
     ]
   },
+  shouldLock: {
+    description: 'Should this action be performed one at a time (avoid concurrency)? Only available for create.',
+    type: 'boolean',
+  },
   inputFields: BasicActionOperationSchema.properties.inputFields,
   outputFields: BasicActionOperationSchema.properties.outputFields,
   sample: BasicActionOperationSchema.properties.sample,

--- a/lib/schemas/BasicCreateActionOperationSchema.js
+++ b/lib/schemas/BasicCreateActionOperationSchema.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const makeSchema = require('../utils/makeSchema');
+
+const BasicActionOperationSchema = require('./BasicActionOperationSchema');
+
+// TODO: would be nice to deep merge these instead
+// or maybe use allOf which is built into json-schema
+const BasicCreateActionOperationSchema = JSON.parse(JSON.stringify(BasicActionOperationSchema.schema));
+
+BasicCreateActionOperationSchema.id = '/BasicCreateActionOperationSchema';
+BasicCreateActionOperationSchema.description = 'Represents the fundamental mechanics of a create.';
+
+BasicCreateActionOperationSchema.properties.shouldLock = {
+  description: 'Should this action be performed one at a time (avoid concurrency)?',
+  type: 'boolean',
+};
+
+module.exports = makeSchema(BasicCreateActionOperationSchema, BasicActionOperationSchema.dependencies);

--- a/lib/schemas/CreateSchema.js
+++ b/lib/schemas/CreateSchema.js
@@ -6,7 +6,7 @@ const BasicDisplaySchema = require('./BasicDisplaySchema');
 const BasicActionOperationSchema = require('./BasicActionOperationSchema');
 const KeySchema = require('./KeySchema');
 
-const CreateSchema = makeSchema({
+module.exports = makeSchema({
   id: '/CreateSchema',
   description: 'How will Zapier create a new object?',
   type: 'object',
@@ -45,5 +45,3 @@ const CreateSchema = makeSchema({
   BasicActionOperationSchema,
   KeySchema,
 ]);
-
-module.exports = CreateSchema;

--- a/lib/schemas/CreateSchema.js
+++ b/lib/schemas/CreateSchema.js
@@ -3,7 +3,7 @@
 const makeSchema = require('../utils/makeSchema');
 
 const BasicDisplaySchema = require('./BasicDisplaySchema');
-const BasicActionOperationSchema = require('./BasicActionOperationSchema');
+const BasicCreateActionOperationSchema = require('./BasicCreateActionOperationSchema');
 const KeySchema = require('./KeySchema');
 
 module.exports = makeSchema({
@@ -36,12 +36,12 @@ module.exports = makeSchema({
     },
     operation: {
       description: 'Powers the functionality for this create.',
-      $ref: BasicActionOperationSchema.id
+      $ref: BasicCreateActionOperationSchema.id
     }
   },
   additionalProperties: false
 }, [
   BasicDisplaySchema,
-  BasicActionOperationSchema,
+  BasicCreateActionOperationSchema,
   KeySchema,
 ]);

--- a/lib/schemas/CreateSchema.js
+++ b/lib/schemas/CreateSchema.js
@@ -6,11 +6,19 @@ const BasicDisplaySchema = require('./BasicDisplaySchema');
 const BasicActionOperationSchema = require('./BasicActionOperationSchema');
 const KeySchema = require('./KeySchema');
 
-module.exports = makeSchema({
+const CreateSchema = makeSchema({
   id: '/CreateSchema',
   description: 'How will Zapier create a new object?',
   type: 'object',
   required: ['key', 'noun', 'display', 'operation'],
+  examples: [
+    {key: 'recipe', noun: 'Recipe', display: {label: 'Create Recipe', description: 'Creates a new recipe.'}, operation: {perform: '$func$2$f$'}},
+    {key: 'recipe', noun: 'Recipe', display: {label: 'Create Recipe', description: 'Creates a new recipe.'}, operation: {perform: '$func$2$f$', shouldLock: true}},
+  ],
+  antiExamples: [
+    'abc',
+    {key: 'recipe', noun: 'Recipe', display: {label: 'Create Recipe', description: 'Creates a new recipe.'}, operation: {perform: '$func$2$f$', shouldLock: 'yes'}},
+  ],
   properties: {
     key: {
       description: 'A key to uniquely identify this create.',
@@ -37,3 +45,5 @@ module.exports = makeSchema({
   BasicActionOperationSchema,
   KeySchema,
 ]);
+
+module.exports = CreateSchema;

--- a/test/index.js
+++ b/test/index.js
@@ -134,7 +134,7 @@ describe('app', () => {
   describe('export', () => {
     it('should export the full schema', () => {
       const exportedSchema = schema.exportSchema();
-      Object.keys(exportedSchema.schemas).length.should.eql(40); // changes regularly as we expand
+      Object.keys(exportedSchema.schemas).length.should.eql(41); // changes regularly as we expand
     });
   });
 


### PR DESCRIPTION
While it's not restricted to creates via schema (we might want to later allow searches or searches-or-creates), it will error in the Zap/Editor if used in anything other than creates for now.

@bcooksey what do you think? Should we force via schema on the Search?