### PR TITLE
Improving error messages

### DIFF
--- a/lib/functional-constraints/deepNestedFields.js
+++ b/lib/functional-constraints/deepNestedFields.js
@@ -8,17 +8,28 @@ const collectErrors = (inputFields, path) => {
 
   _.each(inputFields, (inputField, index) => {
     if (inputField.children) {
-      const hasDeeplyNestedChildren = _.every(inputField.children, (child) => child.children);
-
-      if (hasDeeplyNestedChildren) {
+      if (inputField.children.length === 0) {
         errors.push(new jsonschema.ValidationError(
-          'must not contain deeply nested child fields. One level max.',
+          'must not be empty.',
           inputField,
           '/FieldSchema',
-          `instance.${path}.inputFields[${index}]`,
-          'deepNesting',
+          `instance.${path}.inputFields[${index}].children`,
+          'empty',
           'inputFields'
         ));
+      } else {
+        const hasDeeplyNestedChildren = _.every(inputField.children, (child) => child.children);
+
+        if (hasDeeplyNestedChildren) {
+          errors.push(new jsonschema.ValidationError(
+            'must not contain deeply nested child fields. One level max.',
+            inputField,
+            '/FieldSchema',
+            `instance.${path}.inputFields[${index}]`,
+            'deepNesting',
+            'inputFields'
+          ));
+        }
       }
     }
   });

--- a/lib/schemas/DynamicFieldsSchema.js
+++ b/lib/schemas/DynamicFieldsSchema.js
@@ -2,35 +2,23 @@
 
 const makeSchema = require('../utils/makeSchema');
 
-const FieldSchema = require('./FieldSchema');
-const FunctionSchema = require('./FunctionSchema');
+const FieldOrFunctionSchema = require('./FieldOrFunctionSchema');
 
 module.exports = makeSchema({
   id: '/DynamicFieldsSchema',
   description: 'Like [/FieldsSchema](#fieldsschema) but you can provide functions to create dynamic or custom fields.',
   examples: [
     [],
-    '$func$2$f$',
     [{key: 'abc'}],
     [{key: 'abc'}, '$func$2$f$'],
+    ['$func$2$f$', '$func$2$f$'],
   ],
   antiExamples: [
     [{}],
     [{key: 'abc', choices: {}}],
+    '$func$2$f$',
   ],
-  oneOf: [
-    {
-      type: 'array',
-      items: {
-        oneOf: [
-          {$ref: FieldSchema.id},
-          {$ref: FunctionSchema.id}
-        ]
-      },
-    },
-    {$ref: FunctionSchema.id}
-  ]
+  $ref: FieldOrFunctionSchema.id,
 }, [
-  FieldSchema,
-  FunctionSchema,
+  FieldOrFunctionSchema,
 ]);

--- a/lib/schemas/FieldOrFunctionSchema.js
+++ b/lib/schemas/FieldOrFunctionSchema.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const makeSchema = require('../utils/makeSchema');
+
+const FieldSchema = require('./FieldSchema');
+const FunctionSchema = require('./FunctionSchema');
+
+// This schema was created to improve readability on errors.
+
+module.exports = makeSchema({
+  id: '/FieldOrFunctionSchema',
+  description: 'Represents an array of fields or functions.',
+  examples: [
+    [],
+    [{key: 'abc'}],
+    [{key: 'abc'}, '$func$2$f$'],
+    ['$func$2$f$', '$func$2$f$'],
+  ],
+  antiExamples: [
+    [{}],
+    [{key: 'abc', choices: {}}],
+    '$func$2$f$',
+  ],
+  type: 'array',
+  items: {
+    oneOf: [
+      {$ref: FieldSchema.id},
+      {$ref: FunctionSchema.id}
+    ]
+  },
+}, [
+  FieldSchema,
+  FunctionSchema,
+]);

--- a/test/functional-constraints/deepNestedFields.js
+++ b/test/functional-constraints/deepNestedFields.js
@@ -37,6 +37,7 @@ describe('deepNestedFields', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(0);
   });
+
   it('should error on fields nested more than one level deep', () => {
     const definition = {
       version: '1.0.0',
@@ -73,5 +74,36 @@ describe('deepNestedFields', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql('instance.creates.foo.inputFields[1] must not contain deeply nested child fields. One level max.');
+  });
+
+  it('should error on fields with empty children', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {key: 'orderId', type: 'number'},
+              {
+                key: 'line_items',
+                children: []
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[1].children must not be empty.');
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -134,7 +134,7 @@ describe('app', () => {
   describe('export', () => {
     it('should export the full schema', () => {
       const exportedSchema = schema.exportSchema();
-      Object.keys(exportedSchema.schemas).length.should.eql(41); // changes regularly as we expand
+      Object.keys(exportedSchema.schemas).length.should.eql(42); // changes regularly as we expand
     });
   });
 

--- a/test/readability.js
+++ b/test/readability.js
@@ -3,6 +3,7 @@
 require('should');
 
 const AuthenticationSchema = require('../lib/schemas/AuthenticationSchema');
+const CreateSchema = require('../lib/schemas/CreateSchema');
 
 
 describe('readability', () => {
@@ -14,6 +15,60 @@ describe('readability', () => {
     });
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql('instance.test is not exactly one from </RequestSchema>,</FunctionSchema>');
+  });
+
+  it('should have decent messages for minimum length not met', () => {
+    const results = CreateSchema.validate({
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: '',
+        description: 'Creates a new recipe.',
+      },
+      operation: {
+        perform: '$func$2$f$',
+      },
+    });
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.display.label does not meet minimum length of 2');
+  });
+
+  it('should have decent messages for value type mismatch', () => {
+    let results = CreateSchema.validate({
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Create Recipe',
+        description: 'Creates a new recipe.',
+      },
+      operation: {
+        perform: '$func$2$f$',
+        inputFields: [
+          false,
+        ],
+      },
+    });
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.operation.inputFields[0] is not exactly one from </FieldSchema>,</FunctionSchema>');
+
+    results = CreateSchema.validate({
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Create Recipe',
+        description: 'Creates a new recipe.',
+      },
+      operation: {
+        perform: '$func$2$f$',
+        inputFields: [
+          {key: 'field', type: 'string', default: ''},
+        ],
+      },
+    });
+    results.errors.should.have.length(1);
+    // Ideally it would be the commented version, but it would require significant changes in jsonschema
+    // results.errors[0].stack.should.eql('instance.operation.inputFields[0].default does not meet minimum length of 1');
+    results.errors[0].stack.should.eql('instance.operation.inputFields[0] is not exactly one from </FieldSchema>,</FunctionSchema>');
   });
 
 });


### PR DESCRIPTION
Specifically when a field has an empty array in .children and other kinds of invalid values, showing which field with `</FieldSchema>,</FunctionSchema>` instead of "anything" in `[subschema 0],</FunctionSchema>`.

Fixes #22