### PR TITLE
Adding mutually-exclusive fields functional validation

### DIFF
--- a/lib/functional-constraints/index.js
+++ b/lib/functional-constraints/index.js
@@ -12,7 +12,8 @@
 */
 const checks = [
   require('./searchOrCreateKeys'),
-  require('./deepNestedFields')
+  require('./deepNestedFields'),
+  require('./mutuallyExclusiveFields'),
 ];
 
 const runFunctionalConstraints = (definition) => {

--- a/lib/functional-constraints/mutuallyExclusiveFields.js
+++ b/lib/functional-constraints/mutuallyExclusiveFields.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const _ = require('lodash');
+const jsonschema = require('jsonschema');
+
+// NOTE: While it would be possible to accomplish this with a solution like
+//   https://stackoverflow.com/questions/28162509/mutually-exclusive-property-groups#28172831
+//   it was harder to read and understand.
+
+const incompatibleFields = [
+  ['children', 'list'],
+  ['dict', 'list'],
+  ['dynamic', 'dict'],
+  ['dynamic', 'choices'],
+];
+
+const collectErrors = (inputFields, path) => {
+  const errors = [];
+
+  _.each(inputFields, (inputField, index) => {
+    _.each(incompatibleFields, (fieldGroup) => {
+      if (inputField.hasOwnProperty(fieldGroup[0]) && inputField.hasOwnProperty(fieldGroup[1])) {
+        errors.push(new jsonschema.ValidationError(
+          `must not contain ${fieldGroup[0]} and ${fieldGroup[1]}, as they're mutually exclusive.`,
+          inputField,
+          '/FieldSchema',
+          `instance.${path}.inputFields[${index}]`,
+          'invalid',
+          'inputFields'
+        ));
+      }
+    });
+  });
+
+  return errors;
+};
+
+const mutuallyExclusiveFields = (definition) => {
+  let errors = [];
+
+  _.each(['triggers', 'searches', 'creates'], (typeOf) => {
+    if (definition[typeOf]) {
+      _.each(definition[typeOf], (actionDef) => {
+        if (actionDef.operation && actionDef.operation.inputFields) {
+          errors = errors.concat(collectErrors(actionDef.operation.inputFields, `${typeOf}.${actionDef.key}`));
+        }
+      });
+    }
+  });
+
+  return errors;
+};
+
+module.exports = mutuallyExclusiveFields;

--- a/lib/functional-constraints/mutuallyExclusiveFields.js
+++ b/lib/functional-constraints/mutuallyExclusiveFields.js
@@ -8,20 +8,25 @@ const jsonschema = require('jsonschema');
 //   it was harder to read and understand.
 
 const incompatibleFields = [
-  ['children', 'list'],
-  ['dict', 'list'],
-  ['dynamic', 'dict'],
-  ['dynamic', 'choices'],
+  ['children', 'list'], // This is actually a Feature Request (https://github.com/zapier/zapier-platform-cli/issues/115)
+  ['children', 'dict'], // dict is ignored
+  ['children', 'type'], // type is ignored
+  ['children', 'placeholder'], // placeholder is ignored
+  ['children', 'helpText'], // helpText is ignored
+  ['children', 'default'], // default is ignored
+  ['dict', 'list'], // Use only one or the other
+  ['dynamic', 'dict'], // dict is ignored
+  ['dynamic', 'choices'], // choices are ignored
 ];
 
-const collectErrors = (inputFields, path) => {
+const verifyIncompatibilities = (inputFields, path) => {
   const errors = [];
 
   _.each(inputFields, (inputField, index) => {
-    _.each(incompatibleFields, (fieldGroup) => {
-      if (inputField.hasOwnProperty(fieldGroup[0]) && inputField.hasOwnProperty(fieldGroup[1])) {
+    _.each(incompatibleFields, ([firstField, secondField]) => {
+      if (_.has(inputField, firstField) && _.has(inputField, secondField)) {
         errors.push(new jsonschema.ValidationError(
-          `must not contain ${fieldGroup[0]} and ${fieldGroup[1]}, as they're mutually exclusive.`,
+          `must not contain ${firstField} and ${secondField}, as they're mutually exclusive.`,
           inputField,
           '/FieldSchema',
           `instance.${path}.inputFields[${index}]`,
@@ -42,7 +47,7 @@ const mutuallyExclusiveFields = (definition) => {
     if (definition[typeOf]) {
       _.each(definition[typeOf], (actionDef) => {
         if (actionDef.operation && actionDef.operation.inputFields) {
-          errors = errors.concat(collectErrors(actionDef.operation.inputFields, `${typeOf}.${actionDef.key}`));
+          errors = [...errors, ...verifyIncompatibilities(actionDef.operation.inputFields, `${typeOf}.${actionDef.key}`)];
         }
       });
     }

--- a/test/functional-constraints/mutuallyExclusiveFields.js
+++ b/test/functional-constraints/mutuallyExclusiveFields.js
@@ -1,0 +1,184 @@
+'use strict';
+
+require('should');
+const schema = require('../../schema');
+
+describe('mutuallyExclusiveFields', () => {
+
+  it('should not error on fields not mutually exclusive', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {key: 'orderId', type: 'number'},
+              {
+                key: 'line_items',
+                children: [
+                  {
+                    key: 'product', type: 'string',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(0);
+  });
+
+  it('should error on fields that have children and list', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {key: 'orderId', type: 'number'},
+              {
+                key: 'line_items',
+                children: [
+                  {
+                    key: 'product',
+                  },
+                ],
+                list: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[1] must not contain children and list, as they\'re mutually exclusive.');
+  });
+
+  it('should error on fields that have list and dict', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {key: 'orderId', type: 'number'},
+              {
+                key: 'line_items',
+                dict: true,
+                list: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[1] must not contain dict and list, as they\'re mutually exclusive.');
+  });
+
+  it('should error on fields that have dynamic and dict', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {
+                key: 'orderId',
+                type: 'number',
+                dynamic: 'foo.id.number',
+                dict: true,
+              },
+              {
+                key: 'line_items',
+                list: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[0] must not contain dynamic and dict, as they\'re mutually exclusive.');
+  });
+
+  it('should error on fields that have dynamic and choices', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            inputFields: [
+              {
+                key: 'orderId',
+                type: 'number',
+                dynamic: 'foo.id.number',
+                choices: {
+                  uno: 1,
+                  dos: 2
+                },
+              },
+              {
+                key: 'line_items',
+                list: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+    results.errors[0].stack.should.eql('instance.creates.foo.inputFields[0] must not contain dynamic and choices, as they\'re mutually exclusive.');
+  });
+});


### PR DESCRIPTION
Adding mechanism to validate for mutually-exclusive fields and initial fields that are mutually exclusive

Fixes #21 

[Relevant Trello Card](https://trello.com/c/Pr3LX7by/5-add-more-functional-constraints-to-schema-based-on-properties-that-cant-coexist).

### What this changes

- [x] Adds mechanism to validate against mutually-exclusive fields
- [x] Validates against inputFields that have `children` and `list`
- [x] Validates against inputFields that have `children` and `dict`
- [x] Validates against inputFields that have `children` and `type`
- [x] Validates against inputFields that have `children` and `placeholder`
- [x] Validates against inputFields that have `children` and `helpText`
- [x] Validates against inputFields that have `children` and `default`
- [x] Validates against inputFields that have `dict` and `list`
- [x] Validates against inputFields that have `dynamic` and `dict`
- [x] Validates against inputFields that have `dynamic` and `choices`

### Log

---

**Adding mutually-exclusive fields functional validation** (f00a778)

Adding mechanism to validate for mutually-exclusive fields and initial fields that are mutually exclusive

Fixes #21

---

**Adding more mutually-exclusive fields to the checks** (fbac4a0)

Applying suggestions from code review.

Related to #25