### PR TITLE
Allow docs to match examples from 

### DIFF
--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -162,18 +162,10 @@ Represents authentication schemes.
 #### Examples
 
 * `{ type: 'basic', test: '$func$2$f$' }`
-* `{ type: 'custom',
-  test: '$func$2$f$',
-  fields: [ { key: 'abc' } ] }`
-* `{ type: 'custom',
-  test: '$func$2$f$',
-  connectionLabel: '{{bundle.inputData.abc}}' }`
-* `{ type: 'custom',
-  test: '$func$2$f$',
-  connectionLabel: '$func$2$f$' }`
-* `{ type: 'custom',
-  test: '$func$2$f$',
-  connectionLabel: { url: 'abc' } }`
+* `{ type: 'custom', test: '$func$2$f$', fields: [ { key: 'abc' } ] }`
+* `{ type: 'custom', test: '$func$2$f$', connectionLabel: '{{bundle.inputData.abc}}' }`
+* `{ type: 'custom', test: '$func$2$f$', connectionLabel: '$func$2$f$' }`
+* `{ type: 'custom', test: '$func$2$f$', connectionLabel: { url: 'abc' } }`
 
 #### Anti-Examples
 
@@ -181,9 +173,7 @@ Represents authentication schemes.
 * `'$func$2$f$'`
 * `{ type: 'unknown', test: '$func$2$f$' }`
 * `{ type: 'custom', test: '$func$2$f$', fields: '$func$2$f$' }`
-* `{ type: 'custom',
-  test: '$func$2$f$',
-  fields: [ { key: 'abc' }, '$func$2$f$' ] }`
+* `{ type: 'custom', test: '$func$2$f$', fields: [ { key: 'abc' }, '$func$2$f$' ] }`
 
 #### Properties
 
@@ -285,18 +275,12 @@ Represents user information for a trigger, search, or create.
 #### Examples
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
-* `{ label: 'New Thing',
-  description: 'Gets a new thing for you.',
-  directions: 'This is how you use the thing.',
-  hidden: false,
-  important: true }`
+* `{ label: 'New Thing', description: 'Gets a new thing for you.', directions: 'This is how you use the thing.', hidden: false, important: true }`
 
 #### Anti-Examples
 
 * `{ label: 'New Thing' }`
-* `{ label: 'New Thing',
-  description: 'Gets a new thing for you.',
-  important: 1 }`
+* `{ label: 'New Thing', description: 'Gets a new thing for you.', important: 1 }`
 
 #### Properties
 
@@ -400,33 +384,15 @@ How will Zapier create a new object?
 
 #### Examples
 
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-  operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-  operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'Create Recipe',
-     description: 'Creates a new recipe.',
-     hidden: true },
-  operation: { perform: '$func$2$f$' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Create Recipe', description: 'Creates a new recipe.' }, operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Create Recipe', description: 'Creates a new recipe.' }, operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true }, operation: { perform: '$func$2$f$' } }`
 
 #### Anti-Examples
 
 * `'abc'`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-  operation: { perform: '$func$2$f$', shouldLock: 'yes' } }`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-  operation: { perform: '$func$2$f$' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Create Recipe', description: 'Creates a new recipe.' }, operation: { perform: '$func$2$f$', shouldLock: 'yes' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Create Recipe', description: 'Creates a new recipe.' }, operation: { perform: '$func$2$f$' } }`
 
 #### Properties
 
@@ -580,11 +546,8 @@ Defines a field an app either needs as input, or gives as output.
 * `{ key: 'abc' }`
 * `{ key: 'abc', choices: { mobile: 'Mobile Phone' } }`
 * `{ key: 'abc', choices: [ 'first', 'second', 'third' ] }`
-* `{ key: 'abc',
-  choices: [ { label: 'Red', sample: '#f00', value: '#f00' } ] }`
-* `{ key: 'abc', children: [] }`
+* `{ key: 'abc', choices: [ { label: 'Red', sample: '#f00', value: '#f00' } ] }`
 * `{ key: 'abc', children: [ { key: 'abc' } ] }`
-* `{ key: 'abc', children: [ { key: 'abc', children: [] } ] }`
 * `{ key: 'abc', type: 'integer' }`
 
 #### Anti-Examples
@@ -596,6 +559,9 @@ Defines a field an app either needs as input, or gives as output.
 * `{ key: 'abc', choices: [ { label: 'Red', value: '#f00' } ] }`
 * `{ key: 'abc', choices: 'mobile' }`
 * `{ key: 'abc', type: 'loltype' }`
+* `{ key: 'abc', children: [] }`
+* `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
+* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -812,22 +778,12 @@ How will we find create a specific object given inputs? Will be turned into a cr
 
 #### Examples
 
-* `{ display: 
-   { label: 'Create Tag',
-     description: 'Create a new Tag in your account.' },
-  operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
-* `{ display: 
-   { label: 'Create Tag',
-     description: 'Create a new Tag in your account.',
-     hidden: true },
-  operation: { perform: '$func$2$f$' } }`
+* `{ display: { label: 'Create Tag', description: 'Create a new Tag in your account.' }, operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
+* `{ display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true }, operation: { perform: '$func$2$f$' } }`
 
 #### Anti-Examples
 
-* `{ display: 
-   { label: 'Create Tag',
-     description: 'Create a new Tag in your account.' },
-  operation: { perform: '$func$2$f$' } }`
+* `{ display: { label: 'Create Tag', description: 'Create a new Tag in your account.' }, operation: { perform: '$func$2$f$' } }`
 
 #### Properties
 
@@ -850,24 +806,12 @@ How will we get a single object given a unique identifier/id?
 
 #### Examples
 
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.' },
-  operation: 
-   { perform: { url: '$func$0$f$' },
-     sample: { id: 385, name: 'proactive enable ROI' } } }`
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.',
-     hidden: true },
-  operation: { perform: { url: '$func$0$f$' } } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true }, operation: { perform: { url: '$func$0$f$' } } }`
 
 #### Anti-Examples
 
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.' },
-  operation: { perform: { url: '$func$0$f$' } } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: '$func$0$f$' } } }`
 
 #### Properties
 
@@ -890,25 +834,12 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 
 #### Examples
 
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.' },
-  operation: 
-   { type: 'hook',
-     perform: '$func$0$f$',
-     sample: { id: 385, name: 'proactive enable ROI' } } }`
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.',
-     hidden: true },
-  operation: { type: 'hook', perform: '$func$0$f$' } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true }, operation: { type: 'hook', perform: '$func$0$f$' } }`
 
 #### Anti-Examples
 
-* `{ display: 
-   { label: 'Get Tag by ID',
-     description: 'Grab a specific Tag by ID.' },
-  operation: { type: 'hook', perform: '$func$0$f$' } }`
+* `{ display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { type: 'hook', perform: '$func$0$f$' } }`
 
 #### Properties
 
@@ -931,27 +862,12 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 
 #### Examples
 
-* `{ display: 
-   { label: 'New User',
-     description: 'Trigger when a new User is created in your account.' },
-  operation: 
-   { perform: { url: 'http://fake-crm.getsandbox.com/users' },
-     sample: 
-      { id: 49,
-        name: 'Veronica Kuhn',
-        email: 'veronica.kuhn@company.com' } } }`
-* `{ display: 
-   { label: 'New User',
-     description: 'Trigger when a new User is created in your account.',
-     hidden: true },
-  operation: { perform: { url: 'http://fake-crm.getsandbox.com/users' } } }`
+* `{ display: { label: 'New User', description: 'Trigger when a new User is created in your account.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/users' }, sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }`
+* `{ display: { label: 'New User', description: 'Trigger when a new User is created in your account.', hidden: true }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/users' } } }`
 
 #### Anti-Examples
 
-* `{ display: 
-   { label: 'New User',
-     description: 'Trigger when a new User is created in your account.' },
-  operation: { perform: { url: 'http://fake-crm.getsandbox.com/users' } } }`
+* `{ display: { label: 'New User', description: 'Trigger when a new User is created in your account.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/users' } } }`
 
 #### Properties
 
@@ -974,24 +890,12 @@ How will we find a specific object given filters or search terms? Will be turned
 
 #### Examples
 
-* `{ display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.' },
-  operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
-* `{ display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.',
-     hidden: true },
-  operation: { perform: '$func$2$f$' } }`
+* `{ display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' }, operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
+* `{ display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true }, operation: { perform: '$func$2$f$' } }`
 
 #### Anti-Examples
 
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.' },
-  operation: { perform: '$func$2$f$' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' }, operation: { perform: '$func$2$f$' } }`
 
 #### Properties
 
@@ -1014,56 +918,14 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 
 #### Examples
 
-* `{ key: 'tag',
-  noun: 'Tag',
-  get: 
-   { display: 
-      { label: 'Get Tag by ID',
-        description: 'Grab a specific Tag by ID.' },
-     operation: { perform: [Object], sample: [Object] } } }`
-* `{ key: 'tag',
-  noun: 'Tag',
-  sample: { id: 385, name: 'proactive enable ROI' },
-  get: 
-   { display: 
-      { label: 'Get Tag by ID',
-        description: 'Grab a specific Tag by ID.' },
-     operation: { perform: [Object] } } }`
-* `{ key: 'tag',
-  noun: 'Tag',
-  get: 
-   { display: 
-      { label: 'Get Tag by ID',
-        description: 'Grab a specific Tag by ID.',
-        hidden: true },
-     operation: { perform: [Object] } },
-  list: 
-   { display: 
-      { label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.' },
-     operation: { perform: [Object], sample: [Object] } } }`
+* `{ key: 'tag', noun: 'Tag', get: { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' }, sample: { id: 385, name: 'proactive enable ROI' } } } }`
+* `{ key: 'tag', noun: 'Tag', sample: { id: 385, name: 'proactive enable ROI' }, get: { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }`
+* `{ key: 'tag', noun: 'Tag', get: { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } }, list: { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags' }, sample: { id: 385, name: 'proactive enable ROI' } } } }`
 
 #### Anti-Examples
 
-* `{ key: 'tag',
-  noun: 'Tag',
-  get: 
-   { display: 
-      { label: 'Get Tag by ID',
-        description: 'Grab a specific Tag by ID.' },
-     operation: { perform: [Object] } },
-  list: 
-   { display: 
-      { label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.' },
-     operation: { perform: [Object], sample: [Object] } } }`
-* `{ key: 'tag',
-  noun: 'Tag',
-  get: 
-   { display: 
-      { label: 'Get Tag by ID',
-        description: 'Grab a specific Tag by ID.' },
-     operation: { perform: [Object] } } }`
+* `{ key: 'tag', noun: 'Tag', get: { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } }, list: { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags' }, sample: { id: 385, name: 'proactive enable ROI' } } } }`
+* `{ key: 'tag', noun: 'Tag', get: { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' }, operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }`
 
 #### Properties
 
@@ -1168,29 +1030,13 @@ How will Zapier search for existing objects?
 
 #### Examples
 
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.' },
-  operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.',
-     hidden: true },
-  operation: { perform: '$func$2$f$' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' }, operation: { perform: '$func$2$f$', sample: { id: 1 } } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true }, operation: { perform: '$func$2$f$' } }`
 
 #### Anti-Examples
 
 * `'abc'`
-* `{ key: 'recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'Find a Recipe',
-     description: 'Search for recipe by cuisine style.' },
-  operation: { perform: '$func$2$f$' } }`
+* `{ key: 'recipe', noun: 'Recipe', display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' }, operation: { perform: '$func$2$f$' } }`
 
 #### Properties
 
@@ -1235,28 +1081,12 @@ How will Zapier get notified of new objects?
 
 #### Examples
 
-* `{ key: 'new_recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'New Recipe',
-     description: 'Triggers when a new recipe is added.' },
-  operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }`
-* `{ key: 'new_recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'New Recipe',
-     description: 'Triggers when a new recipe is added.',
-     hidden: true },
-  operation: { type: 'polling', perform: '$func$0$f$' } }`
+* `{ key: 'new_recipe', noun: 'Recipe', display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' }, operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }`
+* `{ key: 'new_recipe', noun: 'Recipe', display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true }, operation: { type: 'polling', perform: '$func$0$f$' } }`
 
 #### Anti-Examples
 
-* `{ key: 'new_recipe',
-  noun: 'Recipe',
-  display: 
-   { label: 'New Recipe',
-     description: 'Triggers when a new recipe is added.' },
-  operation: { perform: '$func$0$f$' } }`
+* `{ key: 'new_recipe', noun: 'Recipe', display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' }, operation: { perform: '$func$0$f$' } }`
 
 #### Properties
 

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -533,17 +533,17 @@ Represents an array of fields or functions.
 
 ## /FieldSchema
 
-Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:
+Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following keys are mutually exclusive:
 
-* children & list
-* children & dict
-* children & type
-* children & placeholder
-* children & helpText
-* children & default
-* dict & list
-* dynamic & dict
-* dynamic & choices
+* `children` & `list`
+* `children` & `dict`
+* `children` & `type`
+* `children` & `placeholder`
+* `children` & `helpText`
+* `children` & `default`
+* `dict` & `list`
+* `dynamic` & `dict`
+* `dynamic` & `choices`
 
 #### Details
 

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -533,7 +533,17 @@ Represents an array of fields or functions.
 
 ## /FieldSchema
 
-Defines a field an app either needs as input, or gives as output.
+Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:
+
+* children & list
+* children & dict
+* children & type
+* children & placeholder
+* children & helpText
+* children & default
+* dict & list
+* dynamic & dict
+* dynamic & choices
 
 #### Details
 
@@ -991,7 +1001,7 @@ Pair an existing search and a create to enable "Find or Create" functionality in
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`key` | **yes** | [/KeySchema](#keyschema) | A key to uniquely identify this search-or-create.
+`key` | **yes** | [/KeySchema](#keyschema) | A key to uniquely identify this search-or-create. Must match the search key.
 `display` | **yes** | [/BasicDisplaySchema](#basicdisplayschema) | Configures the UI for this search-or-create.
 `search` | **yes** | [/KeySchema](#keyschema) | The key of the search that powers this search-or-create
 `create` | **yes** | [/KeySchema](#keyschema) | The key of the create that powers this search-or-create

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -129,7 +129,7 @@
     "FieldSchema": {
       "id": "/FieldSchema",
       "description":
-        "Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:\n\n* children & list\n* children & dict\n* children & type\n* children & placeholder\n* children & helpText\n* children & default\n* dict & list\n* dynamic & dict\n* dynamic & choices",
+        "Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following keys are mutually exclusive:\n\n* `children` & `list`\n* `children` & `dict`\n* `children` & `type`\n* `children` & `placeholder`\n* `children` & `helpText`\n* `children` & `default`\n* `dict` & `list`\n* `dynamic` & `dict`\n* `dynamic` & `choices`",
       "type": "object",
       "required": ["key"],
       "properties": {

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -206,7 +206,8 @@
             "$ref": "/FieldSchema"
           },
           "description":
-            "An array of child fields that define the structure of a sub-object for this field. Usually used for line items."
+            "An array of child fields that define the structure of a sub-object for this field. Usually used for line items.",
+          "minItems": 1
         },
         "dict": {
           "description": "Is this field a key/value input?",

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -129,7 +129,7 @@
     "FieldSchema": {
       "id": "/FieldSchema",
       "description":
-        "Defines a field an app either needs as input, or gives as output.",
+        "Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:\n\n* children & list\n* children & dict\n* children & type\n* children & placeholder\n* children & helpText\n* children & default\n* dict & list\n* dynamic & dict\n* dynamic & choices",
       "type": "object",
       "required": ["key"],
       "properties": {
@@ -1102,7 +1102,8 @@
       "required": ["key", "display", "search", "create"],
       "properties": {
         "key": {
-          "description": "A key to uniquely identify this search-or-create.",
+          "description":
+            "A key to uniquely identify this search-or-create. Must match the search key.",
           "$ref": "/KeySchema"
         },
         "display": {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,10 @@
 module.exports = {
   ROOT_GITHUB: 'https://github.com/zapier/zapier-platform-schema',
   DOCS_PATH: 'docs/build/schema.md',
-  MUTUALLY_EXCLUSIVE_FIELDS: [
+  SKIP_KEY: '_skipTest',
+  // the following pairs of keys can't be used together in FieldSchema
+  // they're stored here because they're used in a few places
+  INCOMPATIBLE_FIELD_SCHEMA_KEYS: [
     ['children', 'list'], // This is actually a Feature Request (https://github.com/zapier/zapier-platform-cli/issues/115)
     ['children', 'dict'], // dict is ignored
     ['children', 'type'], // type is ignored

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,15 @@
 module.exports = {
   ROOT_GITHUB: 'https://github.com/zapier/zapier-platform-schema',
-  DOCS_PATH: 'docs/build/schema.md'
+  DOCS_PATH: 'docs/build/schema.md',
+  MUTUALLY_EXCLUSIVE_FIELDS: [
+    ['children', 'list'], // This is actually a Feature Request (https://github.com/zapier/zapier-platform-cli/issues/115)
+    ['children', 'dict'], // dict is ignored
+    ['children', 'type'], // type is ignored
+    ['children', 'placeholder'], // placeholder is ignored
+    ['children', 'helpText'], // helpText is ignored
+    ['children', 'default'], // default is ignored
+    ['dict', 'list'], // Use only one or the other
+    ['dynamic', 'dict'], // dict is ignored
+    ['dynamic', 'choices'] // choices are ignored
+  ]
 };

--- a/lib/functional-constraints/mutuallyExclusiveFields.js
+++ b/lib/functional-constraints/mutuallyExclusiveFields.js
@@ -7,17 +7,7 @@ const jsonschema = require('jsonschema');
 //   https://stackoverflow.com/questions/28162509/mutually-exclusive-property-groups#28172831
 //   it was harder to read and understand.
 
-const incompatibleFields = [
-  ['children', 'list'], // This is actually a Feature Request (https://github.com/zapier/zapier-platform-cli/issues/115)
-  ['children', 'dict'], // dict is ignored
-  ['children', 'type'], // type is ignored
-  ['children', 'placeholder'], // placeholder is ignored
-  ['children', 'helpText'], // helpText is ignored
-  ['children', 'default'], // default is ignored
-  ['dict', 'list'], // Use only one or the other
-  ['dynamic', 'dict'], // dict is ignored
-  ['dynamic', 'choices'] // choices are ignored
-];
+const incompatibleFields = require('../constants').MUTUALLY_EXCLUSIVE_FIELDS;
 
 const verifyIncompatibilities = (inputFields, path) => {
   const errors = [];

--- a/lib/functional-constraints/mutuallyExclusiveFields.js
+++ b/lib/functional-constraints/mutuallyExclusiveFields.js
@@ -7,13 +7,13 @@ const jsonschema = require('jsonschema');
 //   https://stackoverflow.com/questions/28162509/mutually-exclusive-property-groups#28172831
 //   it was harder to read and understand.
 
-const incompatibleFields = require('../constants').MUTUALLY_EXCLUSIVE_FIELDS;
+const { INCOMPATIBLE_FIELD_SCHEMA_KEYS } = require('../constants');
 
 const verifyIncompatibilities = (inputFields, path) => {
   const errors = [];
 
   _.each(inputFields, (inputField, index) => {
-    _.each(incompatibleFields, ([firstField, secondField]) => {
+    _.each(INCOMPATIBLE_FIELD_SCHEMA_KEYS, ([firstField, secondField]) => {
       if (_.has(inputField, firstField) && _.has(inputField, secondField)) {
         errors.push(
           new jsonschema.ValidationError(

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -12,8 +12,8 @@ const mutuallyExclusiveFields = require('../constants')
 module.exports = makeSchema(
   {
     id: '/FieldSchema',
-    description: `Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:\n\n${mutuallyExclusiveFields
-      .map(f => `* ${f.join(' & ')}`)
+    description: `Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following keys are mutually exclusive:\n\n${mutuallyExclusiveFields
+      .map(f => `* ${f.map(x => `\`${x}\``).join(' & ')}`)
       .join('\n')}`,
     type: 'object',
     examples: [

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -20,9 +20,7 @@ module.exports = makeSchema(
         key: 'abc',
         choices: [{ label: 'Red', sample: '#f00', value: '#f00' }]
       },
-      { key: 'abc', children: [] },
       { key: 'abc', children: [{ key: 'abc' }] },
-      { key: 'abc', children: [{ key: 'abc', children: [] }] },
       { key: 'abc', type: 'integer' }
     ],
     antiExamples: [
@@ -33,6 +31,16 @@ module.exports = makeSchema(
       { key: 'abc', choices: [{ label: 'Red', value: '#f00' }] },
       { key: 'abc', choices: 'mobile' },
       { key: 'abc', type: 'loltype' },
+      { key: 'abc', children: [] },
+      {
+        key: 'abc',
+        children: [{ key: 'def', children: [] }]
+      },
+      {
+        key: 'abc',
+        children: [{ key: 'def', children: [{ key: 'dhi' }] }],
+        skip: true
+      },
       { key: 'abc', children: ['$func$2$f$'] }
     ],
     required: ['key'],
@@ -112,7 +120,8 @@ module.exports = makeSchema(
         type: 'array',
         items: { $ref: '/FieldSchema' },
         description:
-          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.'
+          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.',
+        minItems: 1
       },
       dict: {
         description: 'Is this field a key/value input?',

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -6,15 +6,22 @@ const RefResourceSchema = require('./RefResourceSchema');
 
 const FieldChoicesSchema = require('./FieldChoicesSchema');
 
-const mutuallyExclusiveFields = require('../constants')
-  .MUTUALLY_EXCLUSIVE_FIELDS;
+const { SKIP_KEY, INCOMPATIBLE_FIELD_SCHEMA_KEYS } = require('../constants');
+
+// the following takes an array of string arrays (string[][]) and returns the follwing string:
+// * `a` & `b`
+// * `c` & `d`
+// ... etc
+const wrapInBackticks = s => `\`${s}\``;
+const formatBullet = f => `* ${f.map(wrapInBackticks).join(' & ')}`;
+const incompatibleFieldsList = INCOMPATIBLE_FIELD_SCHEMA_KEYS.map(
+  formatBullet
+).join('\n');
 
 module.exports = makeSchema(
   {
     id: '/FieldSchema',
-    description: `Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following keys are mutually exclusive:\n\n${mutuallyExclusiveFields
-      .map(f => `* ${f.map(x => `\`${x}\``).join(' & ')}`)
-      .join('\n')}`,
+    description: `Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following keys are mutually exclusive:\n\n${incompatibleFieldsList}`,
     type: 'object',
     examples: [
       { key: 'abc' },
@@ -43,7 +50,7 @@ module.exports = makeSchema(
       {
         key: 'abc',
         children: [{ key: 'def', children: [{ key: 'dhi' }] }],
-        skip: true
+        [SKIP_KEY]: true
       },
       { key: 'abc', children: ['$func$2$f$'] }
     ],

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -6,11 +6,15 @@ const RefResourceSchema = require('./RefResourceSchema');
 
 const FieldChoicesSchema = require('./FieldChoicesSchema');
 
+const mutuallyExclusiveFields = require('../constants')
+  .MUTUALLY_EXCLUSIVE_FIELDS;
+
 module.exports = makeSchema(
   {
     id: '/FieldSchema',
-    description:
-      'Defines a field an app either needs as input, or gives as output.',
+    description: `Defines a field an app either needs as input, or gives as output. In addition to the requirements below, the following fields are mutually exclusive:\n\n${mutuallyExclusiveFields
+      .map(f => `* ${f.join(' & ')}`)
+      .join('\n')}`,
     type: 'object',
     examples: [
       { key: 'abc' },

--- a/lib/schemas/SearchOrCreateSchema.js
+++ b/lib/schemas/SearchOrCreateSchema.js
@@ -14,7 +14,8 @@ module.exports = makeSchema(
     required: ['key', 'display', 'search', 'create'],
     properties: {
       key: {
-        description: 'A key to uniquely identify this search-or-create.',
+        description:
+          'A key to uniquely identify this search-or-create. Must match the search key.',
         $ref: KeySchema.id
       },
       display: {

--- a/lib/utils/buildDocs.js
+++ b/lib/utils/buildDocs.js
@@ -10,6 +10,7 @@ const links = require('./links');
 
 const NO_DESCRIPTION = '_No description given._';
 const COMBOS = ['anyOf', 'allOf', 'oneOf'];
+const { SKIP_KEY } = require('../constants');
 
 const walkSchemas = (InitSchema, callback) => {
   const recurse = (Schema, parents) => {
@@ -34,7 +35,7 @@ const collectSchemas = InitSchema => {
 const quoteOrNa = val => (val ? `\`${val.replace('`', '')}\`` : '_n/a_');
 
 const formatExample = example => {
-  const ex = _.isPlainObject(example) ? _.omit(example, 'skip') : example;
+  const ex = _.isPlainObject(example) ? _.omit(example, SKIP_KEY) : example;
   return `* ${quoteOrNa(
     // GH parses the newlines in bullets correctly, but it's a good thing to fix
     // docs say Infinity for no line break at all

--- a/lib/utils/buildDocs.js
+++ b/lib/utils/buildDocs.js
@@ -33,6 +33,15 @@ const collectSchemas = InitSchema => {
 
 const quoteOrNa = val => (val ? `\`${val.replace('`', '')}\`` : '_n/a_');
 
+const formatExample = example => {
+  const ex = _.isPlainObject(example) ? _.omit(example, 'skip') : example;
+  return `* ${quoteOrNa(
+    // GH parses the newlines in bullets correctly, but it's a good thing to fix
+    // docs say Infinity for no line break at all
+    util.inspect(ex, { depth: null, breakLength: Infinity })
+  )}`;
+};
+
 // Generate a display of the type (or link to a $ref).
 const typeOrLink = schema => {
   if (schema.type === 'array' && schema.items) {
@@ -65,11 +74,7 @@ const makeExampleSection = Schema => {
   return `\
 #### Examples
 
-${examples
-    .map(example => {
-      return `* ${quoteOrNa(util.inspect(example))}`;
-    })
-    .join('\n')}
+${examples.map(formatExample).join('\n')}
 `;
 };
 
@@ -82,11 +87,7 @@ const makeAntiExampleSection = Schema => {
   return `\
 #### Anti-Examples
 
-${examples
-    .map(example => {
-      return `* ${quoteOrNa(util.inspect(example))}`;
-    })
-    .join('\n')}
+${examples.map(formatExample).join('\n')}
 `;
 };
 

--- a/test/functional-constraints/deepNestedFields.js
+++ b/test/functional-constraints/deepNestedFields.js
@@ -78,38 +78,4 @@ describe('deepNestedFields', () => {
       'instance.creates.foo.inputFields[1] must not contain deeply nested child fields. One level max.'
     );
   });
-
-  it('should error on fields with empty children', () => {
-    const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-      creates: {
-        foo: {
-          key: 'foo',
-          noun: 'Foo',
-          display: {
-            label: 'Create Foo',
-            description: 'Creates a...'
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1 },
-            inputFields: [
-              { key: 'orderId', type: 'number' },
-              {
-                key: 'line_items',
-                children: []
-              }
-            ]
-          }
-        }
-      }
-    };
-
-    const results = schema.validateAppDefinition(definition);
-    results.errors.should.have.length(1);
-    results.errors[0].stack.should.eql(
-      'instance.creates.foo.inputFields[1].children must not be empty.'
-    );
-  });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('should');
+const { SKIP_KEY } = require('../lib/constants');
 
 const testInlineSchemaExamples = name => {
   const Schema = require('../lib/schemas/' + name);
@@ -12,7 +13,7 @@ const testInlineSchemaExamples = name => {
       if (!goods.length) {
         this.skip();
       } else {
-        goods.filter(t => !t.skip).forEach(good => {
+        goods.filter(t => !t[SKIP_KEY]).forEach(good => {
           const errors = Schema.validate(good).errors;
           errors.should.have.length(0);
         });
@@ -23,7 +24,7 @@ const testInlineSchemaExamples = name => {
       if (!bads.length) {
         this.skip();
       } else {
-        bads.filter(t => !t.skip).forEach(bad => {
+        bads.filter(t => !t[SKIP_KEY]).forEach(bad => {
           const errors = Schema.validate(bad).errors;
           errors.should.not.have.length(0);
         });
@@ -33,5 +34,5 @@ const testInlineSchemaExamples = name => {
 };
 
 module.exports = {
-  testInlineSchemaExamples: testInlineSchemaExamples
+  testInlineSchemaExamples
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,7 +12,7 @@ const testInlineSchemaExamples = name => {
       if (!goods.length) {
         this.skip();
       } else {
-        goods.forEach(good => {
+        goods.filter(t => !t.skip).forEach(good => {
           const errors = Schema.validate(good).errors;
           errors.should.have.length(0);
         });
@@ -23,7 +23,7 @@ const testInlineSchemaExamples = name => {
       if (!bads.length) {
         this.skip();
       } else {
-        bads.forEach(bad => {
+        bads.filter(t => !t.skip).forEach(bad => {
           const errors = Schema.validate(bad).errors;
           errors.should.not.have.length(0);
         });


### PR DESCRIPTION
This sort of relates to [PDE-152](https://zapierorg.atlassian.net/browse/PDE-152) in that I looked at this because I was looking at that, but this it it's own thing. 

Examples can now be excluded from tests. This is helpful when they conform to a functional constraint, not a schema level one. Also, made an effort to surprise devs less by putting functional restrictions into the doc.