### PR TITLE
correctly mark grandchildren as invalid

### DIFF
--- a/lib/functional-constraints/deepNestedFields.js
+++ b/lib/functional-constraints/deepNestedFields.js
@@ -20,7 +20,7 @@ const collectErrors = (inputFields, path) => {
           )
         );
       } else {
-        const hasDeeplyNestedChildren = _.every(
+        const hasDeeplyNestedChildren = _.some(
           inputField.children,
           child => child.children
         );

--- a/test/functional-constraints/deepNestedFields.js
+++ b/test/functional-constraints/deepNestedFields.js
@@ -60,6 +60,7 @@ describe('deepNestedFields', () => {
               {
                 key: 'line_items',
                 children: [
+                  { key: 'some do not have children' },
                   {
                     key: 'product',
                     children: [{ key: 'name', type: 'string' }]


### PR DESCRIPTION
fixes https://github.com/zapier/zapier-platform-cli/issues/232 and [PDE-152](https://zapierorg.atlassian.net/browse/PDE-152).

The check would only fail if _all_ items in `children` had a `children` key. We want it to fail if _any_ of them do. 