### PR TITLE
[MAJOR] add matching keys functional constraint

### DIFF
--- a/lib/functional-constraints/index.js
+++ b/lib/functional-constraints/index.js
@@ -14,7 +14,8 @@ const checks = [
   require('./searchOrCreateKeys'),
   require('./deepNestedFields'),
   require('./mutuallyExclusiveFields'),
-  require('./requiredSamples')
+  require('./requiredSamples'),
+  require('./matchingKeys')
 ];
 
 const runFunctionalConstraints = (definition, mainSchema) => {

--- a/lib/functional-constraints/matchingKeys.js
+++ b/lib/functional-constraints/matchingKeys.js
@@ -6,11 +6,6 @@ const jsonschema = require('jsonschema');
 const actionTypes = ['triggers', 'searches', 'creates'];
 
 const matchingKeys = definition => {
-  // if none of the actionTypes are in this, we don't have a top-level definition
-  if (!_.some(actionTypes.map(t => definition[t]), Boolean)) {
-    return [];
-  }
-
   const errors = [];
 
   // verifies that x.key === x

--- a/lib/functional-constraints/matchingKeys.js
+++ b/lib/functional-constraints/matchingKeys.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const _ = require('lodash');
+const jsonschema = require('jsonschema');
+
+const actionTypes = ['triggers', 'searches', 'creates'];
+
+const matchingKeys = definition => {
+  // if none of the actionTypes are in this, we don't have a top-level definition
+  if (!_.some(actionTypes.map(t => definition[t]), Boolean)) {
+    return [];
+  }
+
+  const errors = [];
+
+  // verifies that x.key === x
+  // otherwise, we double results in the compiled app via core's compileApp
+
+  for (const actionType of actionTypes) {
+    const group = definition[actionType] || {};
+    _.each(group, (action, key) => {
+      if (action.key !== key) {
+        errors.push(
+          new jsonschema.ValidationError(
+            `must have a matching top-level key (found "${key}" and "${
+              action.key
+            }")`,
+            action,
+            `/${_.capitalize(actionType)}Schema`,
+            `instance.${key}.key`,
+            'invalid',
+            'key'
+          )
+        );
+      }
+    });
+  }
+
+  return errors;
+};
+
+module.exports = matchingKeys;

--- a/test/functional-constraints/matchingKeys.js
+++ b/test/functional-constraints/matchingKeys.js
@@ -1,0 +1,43 @@
+'use strict';
+
+require('should');
+const schema = require('../../schema');
+
+describe('matchingKeys', () => {
+  it("should error if the keys don't match", () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      triggers: {}, // this should be harmlessly skipped
+      creates: {
+        foo: {
+          key: 'bar', // this is different than above, which shouldn't validate
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...'
+          },
+          operation: {
+            perform: '$func$2$f$',
+            sample: { id: 1 },
+            inputFields: [
+              { key: 'orderId', type: 'number' },
+              {
+                key: 'line_items',
+                children: [
+                  {
+                    key: 'product',
+                    type: 'string'
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(1);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,7 @@ describe('app', () => {
       appCopy.triggers['3contact_by_tag'] = appCopy.triggers.contact_by_tag;
       delete appCopy.triggers.contact_by_tag;
       const results = schema.validateAppDefinition(appCopy);
-      results.errors.length.should.eql(1);
+      results.errors.length.should.eql(2); // invalid name and top-level key doesn't match trigger key
     });
 
     it('should run and pass functional constraints', function() {


### PR DESCRIPTION
Adds a new functional constraint to validate the fact that the top-level key in a trigger/search/create matches the `key` value. Failing to do this causes a wild bug where the trigger is in the definition twice.

This is because in `core`, we run the following in `compileApp` ([link](https://github.com/zapier/zapier-platform-core/blob/9b0cbdadf426b3abb11d48153e0dba8afefd4aa3/src/tools/schema.js#L156-L162)), which copies properties onto the wrong key if they don't match. A simple example: 

```js
const o = { a: { key: "a" }, b: { key: "c" } };

_.each(o, val => {
  o[val.key] = { checked: true, ...val };
});

JSON.stringify(o, null, 2)
```
yields:
```json
{
  "a": {
    "checked": true,
    "key": "a"
  },
  "b": {
    "key": "c"
  },
  "c": {
    "checked": true,
    "key": "c"
  }
}
```

where `c` is in the definition twice, but one is a bad version. 

See: initial slack [report](https://zapier-platform.slack.com/archives/C2S5DGF6G/p1522796619000100)
