### PR TITLE
add doc annotation for hook type

### DIFF
--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -310,7 +310,7 @@ Represents the inbound mechanics of hooks with optional subscribe/unsubscribe. D
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`type` | **yes** (with exceptions, see description) | `string` in (`'hook'`) | Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it's optional
+`type` | **yes** (with exceptions, see description) | `string` in (`'hook'`) | Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it's optional.
 `resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | [/FunctionSchema](#functionschema) | A function that processes the inbound webhook request.
 `performList` | no | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Can get "live" data on demand instead of waiting for a hook. If you find yourself reaching for this - consider resources and their built-in hook/list methods.

--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -310,7 +310,7 @@ Represents the inbound mechanics of hooks with optional subscribe/unsubscribe. D
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`type` | no | `string` in (`'hook'`) | Clarify how this operation works (polling == pull or hook == push).
+`type` | **yes** (with exceptions, see description) | `string` in (`'hook'`) | Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it's optional
 `resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | [/FunctionSchema](#functionschema) | A function that processes the inbound webhook request.
 `performList` | no | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Can get "live" data on demand instead of waiting for a hook. If you find yourself reaching for this - consider resources and their built-in hook/list methods.

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -586,10 +586,15 @@
       "properties": {
         "type": {
           "description":
-            "Clarify how this operation works (polling == pull or hook == push).",
+            "Must be explicitly set to `\"hook\"` unless this hook is defined as part of a resource, in which case it's optional",
           "type": "string",
-          "default": "hook",
-          "enum": ["hook"]
+          "enum": ["hook"],
+          "docAnnotation": {
+            "required": {
+              "type": "replace",
+              "value": "**yes** (with exceptions, see description)"
+            }
+          }
         },
         "resource": {
           "description":

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -586,7 +586,7 @@
       "properties": {
         "type": {
           "description":
-            "Must be explicitly set to `\"hook\"` unless this hook is defined as part of a resource, in which case it's optional",
+            "Must be explicitly set to `\"hook\"` unless this hook is defined as part of a resource, in which case it's optional.",
           "type": "string",
           "enum": ["hook"],
           "docAnnotation": {

--- a/lib/schemas/BasicHookOperationSchema.js
+++ b/lib/schemas/BasicHookOperationSchema.js
@@ -19,12 +19,16 @@ BasicHookOperationSchema.description =
 
 BasicHookOperationSchema.properties = {
   type: {
-    // TODO: not a fan of this...
     description:
-      'Clarify how this operation works (polling == pull or hook == push).',
+      'Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it\'s optional',
     type: 'string',
-    default: 'hook',
-    enum: ['hook']
+    enum: ['hook'],
+    docAnnotation: {
+      required: {
+        type: 'replace',
+        value: '**yes** (with exceptions, see description)'
+      }
+    }
   },
   resource: BasicHookOperationSchema.properties.resource,
   perform: {

--- a/lib/schemas/BasicHookOperationSchema.js
+++ b/lib/schemas/BasicHookOperationSchema.js
@@ -20,7 +20,7 @@ BasicHookOperationSchema.description =
 BasicHookOperationSchema.properties = {
   type: {
     description:
-      'Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it\'s optional',
+      'Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it\'s optional.',
     type: 'string',
     enum: ['hook'],
     docAnnotation: {


### PR DESCRIPTION
It turns out that we only treat a trigger as a hook if this is explicitly true ([code](https://github.com/zapier/zapier/blob/develop/developer_cli/api_base.py#L114)) so we want to note in the docs that standalone hooks must set this or they won't work. 