### PR TITLE
Remove Node 6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6.10.3"
   - "8.10.0"
+  - "10"
 script:
   - npm run coverage
 notifications:
@@ -12,4 +12,5 @@ deploy:
   api_key: $NPM_TOKEN
   on:
     tags: true
+    node: "8.10.0"
   skip_cleanup: true


### PR DESCRIPTION
Looks like we removed Node 6 support from the `cli` package in PR https://github.com/zapier/zapier-platform-cli/pull/328, so there's little reason to keep it here in `schema`.