### PR TITLE
Add 'copy' field type to FieldSchema

### DIFF
--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -90,7 +90,8 @@ module.exports = makeSchema(
           'boolean',
           'datetime',
           'file',
-          'password'
+          'password',
+          'copy'
         ]
       },
       required: {


### PR DESCRIPTION
It's one of the lesser-used field types in Web Builder, but I don't see why it shouldn't be available to CLI apps. It's already present in `FIELD_TYPE_OF_REWRITE_MAP` in core, so I think it should be supported out of the box.