### PR TITLE
Add support for grouping fields into sections

### DIFF
--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -132,7 +132,14 @@ module.exports = makeSchema(
         type: 'array',
         items: { $ref: '/FieldSchema' },
         description:
-          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.',
+          'An array of child fields that define the structure of a sub-array for this field. Used for line items.',
+        minItems: 1
+      },
+      fieldSet: {
+        type: 'array',
+        items: { $ref: '/FieldSchema' },
+        description:
+          'An array of fields that define the structure of a sub-object for this field. Used to group a set of fields into a logical section.',
         minItems: 1
       },
       dict: {


### PR DESCRIPTION
## Current Behaviour

Currently we support a 'children' set of fields that by default always accepts line item (array) input.

## New Behaviour

It would be nice if fields could be grouped into logical sections without allowing array input.

*Example:*

### Product (line items)

* The product section uses the 'children' schema.
* The fields under the product section each accept line item input.

### Address

* The Address section uses the 'fieldSet' schema.
* Each field under address are normal input fields (string, int etc). 
* These fields do not accept line item input.
![eg](https://cdn.zapier.com/storage/photos/7f5e7e86b84e349e9532d191ba5b9012.png)

Looking to explore this new functionality further before merging.

### Related Issue

[Frontend PR with Editor Changes](https://github.com/zapier/zapier/pull/19322)



