### PR TITLE
Add 'legacy' root prop for legacy WB apps

### DIFF
--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -757,7 +757,7 @@ Internal pointer to a function from the original source or the source code itsel
 
 ## /FunctionSourceSchema
 
-Source code like {source: "return 1 + 2"} which the system will wrap in a function for you.
+Source code like `{source: "return 1 + 2"}` which the system will wrap in a function for you.
 
 #### Details
 
@@ -768,6 +768,7 @@ Source code like {source: "return 1 + 2"} which the system will wrap in a functi
 #### Examples
 
 * `{ source: 'return 1 + 2' }`
+* `{ args: [ 'x', 'y' ], source: 'return x + y;' }`
 
 #### Anti-Examples
 
@@ -777,7 +778,8 @@ Source code like {source: "return 1 + 2"} which the system will wrap in a functi
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`source` | **yes** | `string` | _No description given._
+`source` | **yes** | `string` | JavaScript code for the function body. This must end with a `return` statement.
+`args` | no | `array`[`string`] | Function signature. Defaults to `['z', 'bundle']` if not specified.
 
 -----
 

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -74,6 +74,14 @@
           "description":
             "All the search-or-create combos for your app. You can create your own here, or Zapier will automatically register any from resources that define a search, a create, and a get (or define a searchOrCreate directly). Register non-resource search-or-creates here as well.",
           "$ref": "/SearchOrCreatesSchema"
+        },
+        "legacy": {
+          "description":
+            "**INTERNAL USE ONLY**. Zapier uses this to hold properties from a legacy Web Builder app.",
+          "type": "object",
+          "docAnnotation": {
+            "hide": true
+          }
         }
       },
       "additionalProperties": false
@@ -259,14 +267,24 @@
     "FunctionSourceSchema": {
       "id": "/FunctionSourceSchema",
       "description":
-        "Source code like {source: \"return 1 + 2\"} which the system will wrap in a function for you.",
+        "Source code like `{source: \"return 1 + 2\"}` which the system will wrap in a function for you.",
       "type": "object",
       "additionalProperties": false,
       "required": ["source"],
       "properties": {
         "source": {
           "type": "string",
-          "pattern": "return"
+          "pattern": "return",
+          "description":
+            "JavaScript code for the function body. This must end with a `return` statement."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description":
+            "Function signature. Defaults to `['z', 'bundle']` if not specified."
         }
       }
     },

--- a/lib/schemas/AppSchema.js
+++ b/lib/schemas/AppSchema.js
@@ -88,6 +88,14 @@ module.exports = makeSchema(
         description:
           'All the search-or-create combos for your app. You can create your own here, or Zapier will automatically register any from resources that define a search, a create, and a get (or define a searchOrCreate directly). Register non-resource search-or-creates here as well.',
         $ref: SearchOrCreatesSchema.id
+      },
+      legacy: {
+        description:
+          '**INTERNAL USE ONLY**. Zapier uses this to hold properties from a legacy Web Builder app.',
+        type: 'object',
+        docAnnotation: {
+          hide: true
+        }
       }
     },
     additionalProperties: false

--- a/lib/schemas/FunctionSourceSchema.js
+++ b/lib/schemas/FunctionSourceSchema.js
@@ -5,13 +5,27 @@ const makeSchema = require('../utils/makeSchema');
 module.exports = makeSchema({
   id: '/FunctionSourceSchema',
   description:
-    'Source code like {source: "return 1 + 2"} which the system will wrap in a function for you.',
-  examples: [{ source: 'return 1 + 2' }],
+    'Source code like `{source: "return 1 + 2"}` which the system will wrap in a function for you.',
+  examples: [
+    { source: 'return 1 + 2' },
+    { args: ['x', 'y'], source: 'return x + y;' }
+  ],
   antiExamples: [{ source: '1 + 2' }],
   type: 'object',
   additionalProperties: false,
   required: ['source'],
   properties: {
-    source: { type: 'string', pattern: 'return' }
+    source: {
+      type: 'string',
+      pattern: 'return',
+      description:
+        'JavaScript code for the function body. This must end with a `return` statement.'
+    },
+    args: {
+      type: 'array',
+      items: { type: 'string' },
+      description:
+        "Function signature. Defaults to `['z', 'bundle']` if not specified."
+    }
   }
 });

--- a/lib/utils/buildDocs.js
+++ b/lib/utils/buildDocs.js
@@ -109,7 +109,9 @@ ${examples.map(formatExample).join('\n')}
 
 const processProperty = (key, property, propIsRequired) => {
   let isRequired = propIsRequired ? '**yes**' : 'no';
-  if (_.get(property, 'docAnnotation.required')) {
+  if (_.get(property, 'docAnnotation.hide')) {
+    return '';
+  } else if (_.get(property, 'docAnnotation.required')) {
     // can also support keys besides "required"
     const annotation = property.docAnnotation.required;
     if (annotation.type === 'replace') {

--- a/test/index.js
+++ b/test/index.js
@@ -184,6 +184,20 @@ describe('app', () => {
       error.name.should.eql('pattern');
       error.instance.should.eql('https://{{input}.example.com');
     });
+
+    it('should validate legacy properties', () => {
+      const appCopy = copy(appDefinition);
+      appCopy.legacy = {
+        subscribeUrl: 'https://example.com',
+        triggers: {
+          contact: {
+            url: 'https://example.com'
+          }
+        }
+      };
+      const results = schema.validateAppDefinition(appCopy);
+      results.errors.should.eql([]);
+    });
   });
 
   describe('export', () => {


### PR DESCRIPTION
Addresses [PDE-538](https://zapierorg.atlassian.net/browse/PDE-538). Adds a `legacy` root prop in the app definition to hold any properties from a legacy Web Builder app. I don't want to put any restrictions on this `legacy` prop. It's a free-form object, so we'll be free to add or remove properties in it without changing the schema.

This PR also improves the doc on `FunctionSourceSchema` and adds a `docAnnotation.hide` option to hide internal stuff from the doc.