### PR TITLE
attempt to hoist better errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 2018
   },
   "env": {
     "node": true,

--- a/lib/utils/makeValidator.js
+++ b/lib/utils/makeValidator.js
@@ -22,11 +22,11 @@ const makeLinks = (error, makerFunc) => {
 };
 
 const removeFirstAndLastChar = s => s.slice(1, -1);
+// always return a string
 const makePath = (path, newSegment) =>
-  path ? [path, newSegment].join('.') : newSegment;
+  (path ? [path, newSegment].join('.') : newSegment) || '';
 
 const processBaseError = (err, path) => {
-  // base case
   const completePath = makePath(path, err.property).replace(
     /\.instance\./g,
     '.'
@@ -38,18 +38,27 @@ const processBaseError = (err, path) => {
 
 const cleanError = (validationError, path, validator) => {
   if (ambiguousTypes.includes(validationError.name)) {
-    // TODO: make this smarter
+    // TODO: make this smarter?
     // if it's triggerSchema, check for "type"
     // if it's request/function, check for "source" or "require". if neither are present, validate against request
 
     // otherwise, maybe raise regular and drop a note to file an issue so we can consider that case?
 
-    // // this has anyOf errors, but they're all just simple type comparisons. Let that bubble up.
-    // if (validationError.schema.id === '/FlatObjectSchema') {
-    //   return processBaseError(validationError, path);
+    let nextSchema;
+    // if (
+    //   isEqual(validationError.argument, [
+    //     '</BasicPollingOperationSchema>',
+    //     '</BasicHookOperationSchema>'
+    //   ])
+    // ) {
+    //   // we can take advantage of type being optional on polling but required on hooks
+    //   nextSchema =
+    //     validationError.argument[
+    //       validationError.instance.type === 'hook' ? 1 : 0
+    //     ];
+    // } else {
+    nextSchema = validationError.argument[0];
     // }
-
-    let nextSchema = validationError.argument[0];
 
     // we have some schemas with anonymous subschemas (such as FieldChoices)
     if (nextSchema.includes('[subschema')) {
@@ -65,6 +74,10 @@ const cleanError = (validationError, path, validator) => {
     }
 
     const res = validator.validate(validationError.instance, nextSchema);
+    if (!res.errors.length) {
+      // this only happens in weird cases
+      return processBaseError(validationError, path);
+    }
     return res.errors.map(e =>
       cleanError(e, makePath(path, validationError.property), validator)
     );
@@ -86,7 +99,6 @@ const makeValidator = (mainSchema, subSchemas) => {
       const allErrors = errors.concat(
         functionalConstraints.run(definition, mainSchema)
       );
-
       const cleanedErrors = flattenDeep(
         allErrors.map(e => cleanError(e, '', v))
       );

--- a/lib/utils/makeValidator.js
+++ b/lib/utils/makeValidator.js
@@ -25,31 +25,52 @@ const removeFirstAndLastChar = s => s.slice(1, -1);
 const makePath = (path, newSegment) =>
   path ? [path, newSegment].join('.') : newSegment;
 
+const processBaseError = (err, path) => {
+  // base case
+  const completePath = makePath(path, err.property).replace(
+    /\.instance\./g,
+    '.'
+  );
+
+  err.property = completePath;
+  return err;
+};
+
 const cleanError = (validationError, path, validator) => {
   if (ambiguousTypes.includes(validationError.name)) {
     // TODO: make this smarter
     // if it's triggerSchema, check for "type"
     // if it's request/function, check for "source" or "require". if neither are present, validate against request
-    // if it's flatobject, probably just raise the regular one, it says it has to be a primative
-    // otherwise, maybe raise regular and drop a note to file an issue so we can consider that case?
-    const nextSchema = validationError.argument[0];
 
-    const res = validator.validate(
-      validationError.instance,
-      validator.schemas[removeFirstAndLastChar(nextSchema)]
-    );
+    // otherwise, maybe raise regular and drop a note to file an issue so we can consider that case?
+
+    // // this has anyOf errors, but they're all just simple type comparisons. Let that bubble up.
+    // if (validationError.schema.id === '/FlatObjectSchema') {
+    //   return processBaseError(validationError, path);
+    // }
+
+    let nextSchema = validationError.argument[0];
+
+    // we have some schemas with anonymous subschemas (such as FieldChoices)
+    if (nextSchema.includes('[subschema')) {
+      const namedSchema = validator.schemas[validationError.schema];
+
+      if (!namedSchema) {
+        return processBaseError(validationError, path);
+      }
+
+      nextSchema = namedSchema[validationError.name][0];
+    } else {
+      nextSchema = validator.schemas[removeFirstAndLastChar(nextSchema)];
+    }
+
+    const res = validator.validate(validationError.instance, nextSchema);
     return res.errors.map(e =>
       cleanError(e, makePath(path, validationError.property), validator)
     );
   } else {
     // base case
-    const completePath = makePath(path, validationError.property).replace(
-      /\.instance\./g,
-      '.'
-    );
-
-    validationError.property = completePath;
-    return validationError;
+    return processBaseError(validationError, path);
   }
 };
 

--- a/lib/utils/makeValidator.js
+++ b/lib/utils/makeValidator.js
@@ -3,12 +3,11 @@
 const jsonschema = require('jsonschema');
 const links = require('./links');
 const functionalConstraints = require('../functional-constraints');
-const { flattenDeep } = require('lodash');
+const { flattenDeep, get } = require('lodash');
 
 const ambiguousTypes = ['anyOf', 'oneOf', 'allOf'];
 
 const makeLinks = (error, makerFunc) => {
-  // debugger; // eslint-disable-line no-debugger
   if (typeof error.schema === 'string') {
     return [makerFunc(error.schema)];
   }
@@ -31,10 +30,9 @@ const makePath = (path, newSegment) =>
   (path ? [path, newSegment].join('.') : newSegment) || '';
 
 const processBaseError = (err, path) => {
-  const completePath = makePath(path, err.property).replace(
-    /\.instance\./g,
-    '.'
-  );
+  const completePath = makePath(path, err.property)
+    .replace(/\.instance\.?/g, '.')
+    .replace(/\.instance$/, '');
 
   const subSchemas = err.message.match(/\[subschema \d+\]/g);
   if (subSchemas) {
@@ -62,8 +60,9 @@ const processBaseError = (err, path) => {
  * @param {ValidationError} validationError an individual error
  * @param {string} path current path in the error chain
  * @param {Validator} validator validator object to pass around that has all the schemas
+ * @param {object} definition the original schema we're defining
  */
-const cleanError = (validationError, path, validator) => {
+const cleanError = (validationError, path, validator, definition) => {
   if (ambiguousTypes.includes(validationError.name)) {
     // flatObjectSchema requires each property to be a type. instead of recursing down, it's more valuable to say "hey, it's not of these types"
     if (validationError.argument.every(s => s.includes('subschema'))) {
@@ -89,16 +88,25 @@ const cleanError = (validationError, path, validator) => {
         nextSchema = validator.schemas[removeFirstAndLastChar(schemaName)];
       }
 
-      const res = validator.validate(validationError.instance, nextSchema);
-      if (!res.errors.length) {
-        // This is a case that I can no longer reproduce, but it caused really weird behavior so I'm going to leave this as a canary for now
-        // in theory this should never happen - all schemas at this point should have errors
-        throw new Error(
-          'If you see this, please file an issue at https://github.com/zapier/zapier-platform-cli/issues'
-        );
+      if (validationError.instance === undefined) {
+        // Work around a jsonschema bug: When the value being validated is
+        // falsy, validationError.instance isn't available
+        // See https://github.com/tdegrunt/jsonschema/issues/263
+        const fullPath =
+          path.replace(/^instance\./, '') +
+          validationError.property.replace(/^instance\./, '');
+        validationError.instance = get(definition, fullPath);
       }
+
+      const res = validator.validate(validationError.instance, nextSchema);
+
       return res.errors.map(e =>
-        cleanError(e, makePath(path, validationError.property), validator)
+        cleanError(
+          e,
+          makePath(path, validationError.property),
+          validator,
+          definition
+        )
       );
     });
 
@@ -126,7 +134,7 @@ const makeValidator = (mainSchema, subSchemas) => {
         functionalConstraints.run(definition, mainSchema)
       );
       const cleanedErrors = flattenDeep(
-        allErrors.map(e => cleanError(e, '', v))
+        allErrors.map(e => cleanError(e, '', v, definition))
       );
 
       results.errors = cleanedErrors.map(error => {

--- a/lib/utils/makeValidator.js
+++ b/lib/utils/makeValidator.js
@@ -3,19 +3,54 @@
 const jsonschema = require('jsonschema');
 const links = require('./links');
 const functionalConstraints = require('../functional-constraints');
+const { flattenDeep } = require('lodash');
+
+const ambiguousTypes = ['anyOf', 'oneOf', 'allOf'];
 
 const makeLinks = (error, makerFunc) => {
-  if (typeof error.schema == 'string') {
+  if (typeof error.schema === 'string') {
     return [makerFunc(error.schema)];
   }
   if (
-    ['anyOf', 'oneOf', 'allOf'].indexOf(error.name) !== -1 &&
+    ambiguousTypes.includes(error.name) &&
     error.argument &&
     error.argument.length
   ) {
     return error.argument.map(makerFunc);
   }
   return [];
+};
+
+const removeFirstAndLastChar = s => s.slice(1, -1);
+const makePath = (path, newSegment) =>
+  path ? [path, newSegment].join('.') : newSegment;
+
+const cleanError = (validationError, path, validator) => {
+  if (ambiguousTypes.includes(validationError.name)) {
+    // TODO: make this smarter
+    // if it's triggerSchema, check for "type"
+    // if it's request/function, check for "source" or "require". if neither are present, validate against request
+    // if it's flatobject, probably just raise the regular one, it says it has to be a primative
+    // otherwise, maybe raise regular and drop a note to file an issue so we can consider that case?
+    const nextSchema = validationError.argument[0];
+
+    const res = validator.validate(
+      validationError.instance,
+      validator.schemas[removeFirstAndLastChar(nextSchema)]
+    );
+    return res.errors.map(e =>
+      cleanError(e, makePath(path, validationError.property), validator)
+    );
+  } else {
+    // base case
+    const completePath = makePath(path, validationError.property).replace(
+      /\.instance\./g,
+      '.'
+    );
+
+    validationError.property = completePath;
+    return validationError;
+  }
 };
 
 const makeValidator = (mainSchema, subSchemas) => {
@@ -26,11 +61,16 @@ const makeValidator = (mainSchema, subSchemas) => {
   });
   return {
     validate: definition => {
-      const results = v.validate(definition, mainSchema);
-      results.errors = results.errors.concat(
+      const { errors, ...results } = v.validate(definition, mainSchema);
+      const allErrors = errors.concat(
         functionalConstraints.run(definition, mainSchema)
       );
-      results.errors = results.errors.map(error => {
+
+      const cleanedErrors = flattenDeep(
+        allErrors.map(e => cleanError(e, '', v))
+      );
+
+      results.errors = cleanedErrors.map(error => {
         error.codeLinks = makeLinks(error, links.makeCodeLink);
         error.docLinks = makeLinks(error, links.makeDocLink);
         return error;

--- a/lib/utils/makeValidator.js
+++ b/lib/utils/makeValidator.js
@@ -8,6 +8,7 @@ const { flattenDeep } = require('lodash');
 const ambiguousTypes = ['anyOf', 'oneOf', 'allOf'];
 
 const makeLinks = (error, makerFunc) => {
+  // debugger; // eslint-disable-line no-debugger
   if (typeof error.schema === 'string') {
     return [makerFunc(error.schema)];
   }
@@ -16,7 +17,10 @@ const makeLinks = (error, makerFunc) => {
     error.argument &&
     error.argument.length
   ) {
-    return error.argument.map(makerFunc);
+    // no way to know what the subschema was, so don't create links for it
+    return error.argument
+      .map(s => (s.includes('subschema') ? '' : makerFunc(s)))
+      .filter(Boolean);
   }
   return [];
 };
@@ -32,55 +36,77 @@ const processBaseError = (err, path) => {
     '.'
   );
 
+  const subSchemas = err.message.match(/\[subschema \d+\]/g);
+  if (subSchemas) {
+    subSchemas.forEach((subschema, idx) => {
+      // err.schema is either an anonymous schema object or the name of a named schema
+      if (typeof err.schema === 'string') {
+        // this is basically only for FieldChoicesSchema and I'm not sure why
+        err.message += ' Consult the docs below for valid subschemas.';
+      } else {
+        // the subschemas have a type property
+        err.message = err.message.replace(
+          subschema,
+          err.schema[err.name][idx].type || 'unknown'
+        );
+      }
+    });
+  }
+
   err.property = completePath;
   return err;
 };
 
+/**
+ * We have a lot of `anyOf` schemas that return ambiguous errors. This recurses down the schema until it finds the errors that cause the failures replaces the ambiguity.
+ * @param {ValidationError} validationError an individual error
+ * @param {string} path current path in the error chain
+ * @param {Validator} validator validator object to pass around that has all the schemas
+ */
 const cleanError = (validationError, path, validator) => {
   if (ambiguousTypes.includes(validationError.name)) {
-    // TODO: make this smarter?
-    // if it's triggerSchema, check for "type"
-    // if it's request/function, check for "source" or "require". if neither are present, validate against request
-
-    // otherwise, maybe raise regular and drop a note to file an issue so we can consider that case?
-
-    let nextSchema;
-    // if (
-    //   isEqual(validationError.argument, [
-    //     '</BasicPollingOperationSchema>',
-    //     '</BasicHookOperationSchema>'
-    //   ])
-    // ) {
-    //   // we can take advantage of type being optional on polling but required on hooks
-    //   nextSchema =
-    //     validationError.argument[
-    //       validationError.instance.type === 'hook' ? 1 : 0
-    //     ];
-    // } else {
-    nextSchema = validationError.argument[0];
-    // }
-
-    // we have some schemas with anonymous subschemas (such as FieldChoices)
-    if (nextSchema.includes('[subschema')) {
-      const namedSchema = validator.schemas[validationError.schema];
-
-      if (!namedSchema) {
-        return processBaseError(validationError, path);
-      }
-
-      nextSchema = namedSchema[validationError.name][0];
-    } else {
-      nextSchema = validator.schemas[removeFirstAndLastChar(nextSchema)];
-    }
-
-    const res = validator.validate(validationError.instance, nextSchema);
-    if (!res.errors.length) {
-      // this only happens in weird cases
+    // flatObjectSchema requires each property to be a type. instead of recursing down, it's more valuable to say "hey, it's not of these types"
+    if (validationError.argument.every(s => s.includes('subschema'))) {
       return processBaseError(validationError, path);
     }
-    return res.errors.map(e =>
-      cleanError(e, makePath(path, validationError.property), validator)
-    );
+
+    // Try against each of A, B, and C to take a guess as to which it's closed to
+    // errorGroups will be an array of arrays of errors
+    const errorGroups = validationError.argument.map((schemaName, idx) => {
+      // this is what we'll validate against next
+      let nextSchema;
+      // schemaName is either "[subschema n]" or "/NamedSchema"
+      if (schemaName.startsWith('[subschema')) {
+        const maybeNamedSchema = validator.schemas[validationError.schema];
+
+        if (maybeNamedSchema) {
+          nextSchema = maybeNamedSchema[validationError.name][idx];
+        } else {
+          // hoist the anonymous subschema up
+          nextSchema = validationError.schema[validationError.name][idx];
+        }
+      } else {
+        nextSchema = validator.schemas[removeFirstAndLastChar(schemaName)];
+      }
+
+      const res = validator.validate(validationError.instance, nextSchema);
+      if (!res.errors.length) {
+        // This is a case that I can no longer reproduce, but it caused really weird behavior so I'm going to leave this as a canary for now
+        // in theory this should never happen - all schemas at this point should have errors
+        throw new Error(
+          'If you see this, please file an issue at https://github.com/zapier/zapier-platform-cli/issues'
+        );
+      }
+      return res.errors.map(e =>
+        cleanError(e, makePath(path, validationError.property), validator)
+      );
+    });
+
+    // find the group with the fewest errors, that's probably the most accurate
+    // if we're goign to tweak what gets returned, this is where we'll do it
+    // a possible improvement could be treating a longer path favorably, like the python implementation does
+    errorGroups.sort((a, b) => a.length - b.length);
+    return errorGroups[0];
   } else {
     // base case
     return processBaseError(validationError, path);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "version": "npm run build && npm run add",
     "postversion": "git push && git push --tags",
     "test": "mocha -t 5000 --recursive test",
+    "test:debug": "mocha -t 5000 --recursive --inspect-brk test",
     "posttest": "eslint lib",
     "smoke-test": "mocha -t 5000 --recursive smoke-test",
     "coverage": "istanbul cover _mocha -- --recursive",

--- a/test/readability.js
+++ b/test/readability.js
@@ -14,6 +14,7 @@ describe('readability', () => {
     });
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql('instance is not of a type(s) object');
+    should(results.errors[0].property.endsWith('instance')).be.false();
   });
 
   it('should have decent messages for minimum length not met', () => {
@@ -30,6 +31,7 @@ describe('readability', () => {
       }
     });
     results.errors.should.have.length(1);
+    should(results.errors[0].property.endsWith('instance')).be.false();
     results.errors[0].stack.should.eql(
       'instance.display.label does not meet minimum length of 2'
     );
@@ -46,10 +48,30 @@ describe('readability', () => {
       operation: {
         perform: '$func$2$f$',
         sample: { id: 1 },
-        inputFields: [1]
+        inputFields: [123]
       }
     });
     results.errors.should.have.length(1);
+    should(results.errors[0].property.endsWith('instance')).be.false();
+    results.errors[0].stack.should.eql('instance is not of a type(s) object');
+  });
+
+  it('should handle falsy values for objects', () => {
+    const results = CreateSchema.validate({
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Create Recipe',
+        description: 'Creates a new recipe.'
+      },
+      operation: {
+        perform: '$func$2$f$',
+        sample: { id: 1 },
+        inputFields: [0]
+      }
+    });
+    results.errors.should.have.length(1);
+    should(results.errors[0].property.endsWith('instance')).be.false();
     results.errors[0].stack.should.eql('instance is not of a type(s) object');
   });
 
@@ -68,6 +90,7 @@ describe('readability', () => {
       }
     });
     results.errors.should.have.length(1);
+    should(results.errors[0].property.endsWith('instance')).be.false();
     results.errors[0].property.should.eql(
       'instance.operation.inputFields[0].default'
     );
@@ -95,6 +118,7 @@ describe('readability', () => {
     should(
       results.errors[0].message.includes('null,string,object,array')
     ).be.true();
+    should(results.errors[0].property.endsWith('instance')).be.false();
     results.errors[0].docLinks.length.should.eql(0);
   });
 
@@ -125,5 +149,6 @@ describe('readability', () => {
     should(
       results.errors[0].docLinks[0].endsWith('schema.md#fieldchoicesschema')
     ).be.true();
+    should(results.errors[0].property.endsWith('instance')).be.false();
   });
 });


### PR DESCRIPTION
attempt to hoist the real issue when validation throws a generic "is not one of x,y"

before

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ = 1 =                                                                                                                        │
│     Property │ App.triggers.blah.operation                                                                                   │
│     Message  │ is not any of </BasicPollingOperationSchema>,</BasicHookOperationSchema>                                      │
│     Links    │ https://github.com/zapier/zapier-platform-schema/blob/v7.6.1/docs/build/schema.md#basicpollingoperationschema │
│              │ https://github.com/zapier/zapier-platform-schema/blob/v7.6.1/docs/build/schema.md#basichookoperationschema    │
└──────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

after

```
┌───────────────────────────────────────────────────────────────┐
│ = 1 =                                                         │
│     Property │ App.triggers.blah.operation.inputFields[0].key │
│     Message  │ does not meet minimum length of 1              │
│     Links    │                                                │
└──────────────┴────────────────────────────────────────────────┘
```