### PR TITLE
Drop help text length requirement

### DIFF
--- a/docs/build/schema.md
+++ b/docs/build/schema.md
@@ -650,7 +650,7 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', choices: [ 'first', 'second', 'third' ] }`
 * `{ key: 'abc', choices: [ { label: 'Red', sample: '#f00', value: '#f00' } ] }`
 * `{ key: 'abc', children: [ { key: 'abc' } ] }`
-* `{ key: 'abc', type: 'integer' }`
+* `{ key: 'abc', type: 'integer', helpText: 'neat' }`
 
 #### Anti-Examples
 
@@ -661,7 +661,7 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', choices: [ { label: 'Red', value: '#f00' } ] }`
 * `{ key: 'abc', choices: 'mobile' }`
 * `{ key: 'abc', type: 'loltype' }`
-* `{ key: 'abc', children: [] }`
+* `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
 * `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`

--- a/exported-schema.json
+++ b/exported-schema.json
@@ -171,7 +171,7 @@
           "description":
             "A human readable description of this value (IE: \"The first part of a full name.\"). You can use Markdown.",
           "type": "string",
-          "minLength": 10,
+          "minLength": 1,
           "maxLength": 1000
         },
         "type": {

--- a/lib/schemas/FieldSchema.js
+++ b/lib/schemas/FieldSchema.js
@@ -32,7 +32,7 @@ module.exports = makeSchema(
         choices: [{ label: 'Red', sample: '#f00', value: '#f00' }]
       },
       { key: 'abc', children: [{ key: 'abc' }] },
-      { key: 'abc', type: 'integer' }
+      { key: 'abc', type: 'integer', helpText: 'neat' }
     ],
     antiExamples: [
       {},
@@ -42,7 +42,7 @@ module.exports = makeSchema(
       { key: 'abc', choices: [{ label: 'Red', value: '#f00' }] },
       { key: 'abc', choices: 'mobile' },
       { key: 'abc', type: 'loltype' },
-      { key: 'abc', children: [] },
+      { key: 'abc', children: [], helpText: '' },
       {
         key: 'abc',
         children: [{ key: 'def', children: [] }]
@@ -72,7 +72,7 @@ module.exports = makeSchema(
         description:
           'A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.',
         type: 'string',
-        minLength: 10,
+        minLength: 1,
         maxLength: 1000
       },
       type: {


### PR DESCRIPTION
Per [this conversation](https://zapier.slack.com/archives/C5Z9BP4U9/p1559810365033000), we need to lower this requirement for converted WB apps (and eventually move it to a style check).

Looking through, I realized we need to keep the 1 char minimum because the frontend doesn't like if the key is there and empty. so totally gone is fine, as is short. but `''` is no good. 